### PR TITLE
fix: resolve code formatting conflicts and remove Periphery

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -14,6 +14,7 @@ disabled_rules:
   - inclusive_language
   - trailing_comma  # SwiftFormat adds trailing commas
   - nesting  # Allow nested types for organization
+  - opening_brace  # SwiftFormat handles brace placement
 
 identifier_name:
   min_length: 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,35 +248,9 @@ swiftlint --fix
 ```
 
 **Configuration**: `.swiftlint.yml` - customized rules for MoleUI:
-- Disabled: `trailing_comma` (SwiftFormat adds them), `nesting` (allows nested types)
+- Disabled: `trailing_comma` (SwiftFormat adds them), `nesting` (allows nested types), `opening_brace` (SwiftFormat handles it)
 - Line length, file length, complexity limits disabled for flexibility
 - Opt-in rules: `empty_count`, `closure_spacing`, etc.
-
-### Periphery
-
-Periphery detects unused code (dead code) in Swift projects.
-
-**Installation**:
-```bash
-brew install peripheryapp/periphery/periphery
-```
-
-**Usage**:
-```bash
-# Scan for unused code
-periphery scan --project MoleUI.xcodeproj --schemes MoleUI
-
-# Clean build before scanning (recommended)
-xcodebuild clean
-periphery scan --project MoleUI.xcodeproj --schemes MoleUI --clean-build
-```
-
-**Note**: Periphery may report false positives for:
-- SwiftUI views (used via reflection)
-- `@Observable` properties (accessed via key paths)
-- Public APIs intended for external use
-
-Review results carefully before removing code.
 
 ### Pre-Commit Checklist
 
@@ -295,9 +269,6 @@ just build
 # 4. Run tests
 xcodebuild -scheme MoleUITests test \
   CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
-
-# 5. (Optional) Check for dead code
-periphery scan --project MoleUI.xcodeproj --schemes MoleUI
 ```
 
 All checks must pass before opening a PR.

--- a/MoleUI/Model/CLIExecutor.swift
+++ b/MoleUI/Model/CLIExecutor.swift
@@ -198,7 +198,8 @@ final class CLIExecutor {
         // 检查 bundle 内
         if let bundled = Bundle.main.resourceURL?
             .appendingPathComponent("mole/mole").path,
-            fm.isExecutableFile(atPath: bundled) {
+            fm.isExecutableFile(atPath: bundled)
+        {
             return bundled
         }
 
@@ -287,7 +288,8 @@ final class CLIExecutor {
             if parts.count == 2,
                let current = Double(parts[0]),
                let total = Double(parts[1]),
-               total > 0 {
+               total > 0
+            {
                 onProgress?(current / total, line)
                 return
             }
@@ -296,7 +298,8 @@ final class CLIExecutor {
         // 进度条格式 [=====>    ]
         if line.contains("["), line.contains("]") {
             if let start = line.firstIndex(of: "["),
-               let end = line.firstIndex(of: "]") {
+               let end = line.firstIndex(of: "]")
+            {
                 let bar = line[line.index(after: start) ..< end]
                 let filled = bar.filter { $0 == "=" || $0 == ">" }.count
                 let total = bar.count

--- a/MoleUI/Model/ErrorTranslator.swift
+++ b/MoleUI/Model/ErrorTranslator.swift
@@ -120,7 +120,8 @@ enum ErrorTranslator {
 
         // 权限错误
         if stderrLower.contains("permission denied") ||
-            stderrLower.contains("operation not permitted") {
+            stderrLower.contains("operation not permitted")
+        {
             return UserFriendlyError(
                 title: "权限不足",
                 message: "没有足够的权限执行此操作",
@@ -136,7 +137,8 @@ enum ErrorTranslator {
 
         // 磁盘空间不足
         if stderrLower.contains("no space left") ||
-            stderrLower.contains("disk full") {
+            stderrLower.contains("disk full")
+        {
             return UserFriendlyError(
                 title: "磁盘空间不足",
                 message: "磁盘空间已满，无法完成操作",
@@ -153,7 +155,8 @@ enum ErrorTranslator {
 
         // 文件不存在
         if stderrLower.contains("no such file") ||
-            stderrLower.contains("not found") {
+            stderrLower.contains("not found")
+        {
             return UserFriendlyError(
                 title: "文件不存在",
                 message: "要操作的文件或目录不存在",
@@ -170,7 +173,8 @@ enum ErrorTranslator {
 
         // 文件正在使用
         if stderrLower.contains("resource busy") ||
-            stderrLower.contains("file is in use") {
+            stderrLower.contains("file is in use")
+        {
             return UserFriendlyError(
                 title: "文件正在使用",
                 message: "某些文件正在被其他程序使用",
@@ -187,7 +191,8 @@ enum ErrorTranslator {
 
         // SIP 保护
         if stderrLower.contains("system integrity protection") ||
-            stderrLower.contains("sip") {
+            stderrLower.contains("sip")
+        {
             return UserFriendlyError(
                 title: "系统保护",
                 message: "此文件受 macOS 系统完整性保护 (SIP)",
@@ -203,7 +208,8 @@ enum ErrorTranslator {
 
         // 网络错误
         if stderrLower.contains("network") ||
-            stderrLower.contains("connection") {
+            stderrLower.contains("connection")
+        {
             return UserFriendlyError(
                 title: "网络错误",
                 message: "网络连接出现问题",

--- a/MoleUI/Model/MetricsModel.swift
+++ b/MoleUI/Model/MetricsModel.swift
@@ -277,7 +277,8 @@ final class MetricsModel {
     private func findBinary() -> URL? {
         // Check bundled binary first (inside .app/Contents/Resources/mole/)
         if let bundled = Bundle.main.resourceURL?
-            .appendingPathComponent("mole/status-go") {
+            .appendingPathComponent("mole/status-go")
+        {
             if FileManager.default.isExecutableFile(atPath: bundled.path) {
                 return bundled
             }

--- a/MoleUI/Model/UninstallModel.swift
+++ b/MoleUI/Model/UninstallModel.swift
@@ -120,13 +120,15 @@ final class AppScanModel {
 
         // 1. Try Spotlight kMDItemLastUsedDate (most accurate when available)
         if let item = MDItemCreateWithURL(nil, url as CFURL),
-           let date = MDItemCopyAttribute(item, kMDItemLastUsedDate) as? Date {
+           let date = MDItemCopyAttribute(item, kMDItemLastUsedDate) as? Date
+        {
             return date
         }
 
         // 2. Try content modification date from Spotlight
         if let item = MDItemCreateWithURL(nil, url as CFURL),
-           let date = MDItemCopyAttribute(item, kMDItemContentModificationDate) as? Date {
+           let date = MDItemCopyAttribute(item, kMDItemContentModificationDate) as? Date
+        {
             return date
         }
 
@@ -139,7 +141,8 @@ final class AppScanModel {
         // 4. Last resort: Info.plist modification date
         let plistURL = url.appendingPathComponent("Contents/Info.plist")
         if let attrs = try? fm.attributesOfItem(atPath: plistURL.path),
-           let date = attrs[.modificationDate] as? Date {
+           let date = attrs[.modificationDate] as? Date
+        {
             return date
         }
 

--- a/MoleUI/Model/VersionModel.swift
+++ b/MoleUI/Model/VersionModel.swift
@@ -24,7 +24,8 @@ final class VersionModel {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .deletingLastPathComponent()
-            .appendingPathComponent(".mole-cli-version") {
+            .appendingPathComponent(".mole-cli-version")
+        {
             if let version = try? String(contentsOf: versionFile, encoding: .utf8) {
                 currentVersion = version.trimmingCharacters(in: .whitespacesAndNewlines)
                 return
@@ -74,12 +75,14 @@ final class VersionModel {
         let fm = FileManager.default
         if let bundled = Bundle.main.resourceURL?
             .appendingPathComponent("mole/mole").path,
-            fm.isExecutableFile(atPath: bundled) {
+            fm.isExecutableFile(atPath: bundled)
+        {
             return bundled
         }
         for path in ["/usr/local/bin/mole", "/opt/homebrew/bin/mole",
                      NSHomeDirectory() + "/.config/mole/mole"]
-            where fm.isExecutableFile(atPath: path) {
+            where fm.isExecutableFile(atPath: path)
+        {
             return path
         }
         return nil


### PR DESCRIPTION
## What
Fix code quality check failures in CI and remove Periphery dead code detection.

## Why
- Initial CI run failed due to SwiftFormat/SwiftLint conflicts
- SwiftFormat's `wrapMultilineStatementBraces` conflicts with SwiftLint's `opening_brace` rule
- Periphery is slow to install and may report false positives for SwiftUI/Observable code

## Changes
- ✅ Disable `opening_brace` rule in .swiftlint.yml to avoid conflicts
- ✅ Apply SwiftFormat to all files (5 files updated)
- ✅ Remove Periphery from CONTRIBUTING.md documentation
- ✅ Simplify Pre-Commit Checklist

## Testing
- ✅ SwiftFormat lint check: 0 files require formatting
- ✅ SwiftLint strict check: 0 violations
- ✅ Project builds successfully

All code quality checks now pass locally.