### PR TITLE
ci: remove notarization timeout limits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,18 +113,16 @@ jobs:
             --team-id "$TEAM_ID"
 
       - name: Notarize app via ZIP
-        timeout-minutes: 20
         run: |
           APP="$RUNNER_TEMP/export/$PRODUCT_NAME.app"
 
           # Create ZIP for notarization (ditto preserves signatures)
           /usr/bin/ditto -c -k --keepParent "$APP" "$RUNNER_TEMP/MoleUI.zip"
 
-          # Submit and wait (Apple says 98% complete within 15 min)
+          # Submit and wait (no timeout - Apple notarization can take a while)
           xcrun notarytool submit "$RUNNER_TEMP/MoleUI.zip" \
             --keychain-profile "notary-profile" \
-            --wait \
-            --timeout 15m
+            --wait
 
           echo "Notarization completed"
 


### PR DESCRIPTION
## What
Remove timeout limits from notarization step in release workflow.

## Why
Apple notarization can sometimes take longer than 15-20 minutes, especially during peak times or for larger apps. Setting timeout limits can cause the workflow to fail unnecessarily.

## Changes
- Remove `timeout-minutes: 20` from notarization step
- Remove `--timeout 15m` flag from `notarytool submit`
- Let notarization run as long as needed

## Testing
Will test with v0.1.0 release after this PR is merged.