### PR TITLE
chore: fix CI signing and update changelog for v0.1.2-beta.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
           xcodebuild -scheme "$SCHEME" \
             -configuration Release \
             -archivePath $RUNNER_TEMP/MoleUI.xcarchive \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO \
             archive
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-> **Architecture Note**: MoleUI now uses a hybrid architecture. The native Swift implementations of the Dashboard, Clean, and Disk Analyzer models have been reverted to delegate to the Mole CLI Go/Bash kernel. This yields better data accuracy, feature parity with the TUI, and reduced maintenance surface.
-
-### Added
-- CLI integration tests in `MoleUITests` covering `CLIExecutor.findMoleRoot`, `findMoleBinary`, and JSON parsing
-- `AppScanModel.errorMessage` state to surface uninstall scan failures to the UI
+## [0.1.2-beta.2] - 2026-03-05
 
 ### Changed
-- `DiskModel`, `MetricsModel`, `UninstallModel`, `VersionModel`: unified Mole binary discovery via `CLIExecutor.findMoleBinary()` (eliminated four duplicate implementations)
-- `AppScanModel.performScan()` now propagates script errors via `throw` instead of silently returning empty results
-- `auto-update-mole.yml`: tag creation now gated on `steps.auto_merge.outputs.merged == 'true'` (prevents releasing if PR merge fails due to CI or branch protection)
-- `AUTO_UPDATE.md`: removed stale native implementation notes; added merge-gate documentation
+- **Disk Analyzer Engine upgrade**: No longer uses Swift native protocol, switched to calling Go kernel (`mole analyze --json`) for significant performance gains.
+- **UI Performance optimization**: Simplified disk analyzer rendering logic and limited display to top 100 entries to fix scrolling lag with large file systems.
+- **Improved UI responsiveness**: Asynchronous loading and better thread management for analyzer tasks.
 
 ### Fixed
-- `auto-update-mole.yml`: version-stripping bug where `V` prefix was being stripped from `RAW_TAG` instead of from `LATEST`
-- `PurgeView.swift`: UI text now correctly shows Application Support path instead of `~/.config/mole`
-- `UninstallModel.swift`: `MOLE_TEST_MODE=1` prevents interactive TUI from blocking non-interactive scan
-- `UninstallModel.swift`: `mktemp` template fixed for macOS compatibility
-- `UninstallModel.swift`: `SCRIPT_DIR` dynamically patched via `sed` for correct dependency resolution
+- Fixed UI thread blocking and scrolling lag in Disk Analyzer view.
+- Added proper sorting for Go kernel results.
 
+### Technical
+- **Architecture Refactor**: Introduced unified `DiskMetrics` protocol to simplify data flow.
+- **Documentation**: Updated architecture and CI/CD documentation.
+
+## [0.1.2-beta.1] - 2026-03-04
+
+### Added
+- One-click clean and optimize functionality
+  - Auto-select safe items after scanning
+  - "Clean All" and "Optimize All" buttons with prominent styling
+  - Collapsible advanced options for unsafe items
+  - Green "safe" badges for safe items
+  - Improved confirmation dialog showing safe vs advanced counts
+- Network history chart improvements
+  - Increased history buffer from 60 to 120 points (4 minutes)
+  - Increased sparkline width from 30 to 60 characters
+  - Better visualization matching Mole TUI behavior
+
+### Changed
+- Clean and Optimize views now default to selecting all safe items
+- Individual "Clean" and "Run" buttons removed for cleaner UI
+- Developer Tools category marked as unsafe (may contain important build artifacts)
+- Network history accumulates over time in MoleUI (fills in ~4-6 minutes)
+
+### Fixed
+- Auto-update workflow path resolution using stable `brew --prefix` method
+- Network history chart not displaying enough data points
+
+### Technical
+- Added `safe` property to CleanCategory and OptimizationTask
+- Added Equatable conformance to data models for onChange detection
+- Added AppStorage preference for auto-selecting safe items
+- Improved user experience with 40% reduction in operation steps (7→5 steps, 5+→2 clicks)
 
 ## [0.1.2] - 2026-03-04
 


### PR DESCRIPTION
This PR fixes the CI signing issue in release.yml by disabling signing during the archive step, and updates the CHANGELOG.md with the Beta 2 release notes.