### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/MoleUI.xcodeproj/project.pbxproj
+++ b/MoleUI.xcodeproj/project.pbxproj
@@ -383,7 +383,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.1.3;
+				MARKETING_VERSION = 0.1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.qinfuyao.MoleUI;
 				PRODUCT_NAME = "Mole UI";
 				SDKROOT = macosx;
@@ -470,7 +470,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.1.3;
+				MARKETING_VERSION = 0.1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.qinfuyao.MoleUI;
 				PRODUCT_NAME = "Mole UI";
 				SDKROOT = macosx;


### PR DESCRIPTION
Update MARKETING_VERSION to 0.1.4 for release tagging.